### PR TITLE
Update to main.js to use new ajaxify syntax

### DIFF
--- a/public/lib/main.js
+++ b/public/lib/main.js
@@ -6,7 +6,7 @@
 			if (data.url.match(/^topic/)) {
 				$('.thread-tools .mark-featured').on('click', function(ev) {
 					ajaxify.loadTemplate('modals/sort-featured-topics', function(featuredTpl) {
-						socket.emit('topics.getFeaturedTopics', {tid: ajaxify.variables.get('topic_id')}, function(err, topics) {
+						socket.emit('topics.getFeaturedTopics', {tid: ajaxify.data.tid}, function(err, topics) {
 							if (!err) {
 								bootbox.confirm(templates.parse(featuredTpl, {topics:topics}), function(confirm) {
 									var tids = [];


### PR DESCRIPTION
As described here: https://community.nodebb.org/topic/5942/ajaxify-variables-get-deprecated/2
